### PR TITLE
create spike integration test generators

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,5 +11,8 @@
         "root": ["./src", "."]
       }],
       "transform-object-rest-spread"
+    ],
+    "ignore": [
+      "**/fixtures"
     ]
 }

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,3 @@
-engines: 
-  eslint:
-    enabled: true
 exclude_paths:
 - "**/templates/"
+- "**/fixtures/"

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 templates/
+fixtures/
 dist/
 .DS_Store
 node_modules/

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-jsx-a11y": "4.0.x",
     "eslint-plugin-react": "6.9.x",
     "eslint-import-resolver-babel-module": "3.0.x",
+    "fs-extra": ">= 3.0.1",
     "mocha": ">= 3.4.1",
     "yeoman-assert": ">= 3.0.0",
     "yeoman-test": ">= 1.6.0"

--- a/src/app/templates/package.json
+++ b/src/app/templates/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "lint": "eslint . --fix",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
-    "dev": "NODE_ENV=development FIXTURES=1 WDS=1 babel-node ./src/server/index.wds.js",
-    "dev:server": "ISOMORPHIC=1 NODE_ENV=development FIXTURES=1 WDS=1 babel-watch ./src/server/index.wds.js",
+    "dev": "NODE_ENV=development WDS=1 babel-node ./src/server/index.wds.js",
+    "dev:server": "ISOMORPHIC=1 NODE_ENV=development WDS=1 babel-watch ./src/server/index.wds.js",
     "start": "node ./dist/server/index.js",
     "babel": "babel",
     "webpack": "webpack",

--- a/src/integrationTests/fixtures/tc1/.dockerignore
+++ b/src/integrationTests/fixtures/tc1/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/integrationTests/fixtures/tc1/.yo-rc.json
+++ b/src/integrationTests/fixtures/tc1/.yo-rc.json
@@ -1,0 +1,5 @@
+{
+  "*": {
+    "integrationTests": true
+  }
+}

--- a/src/integrationTests/fixtures/tc1/.yo-rc.json
+++ b/src/integrationTests/fixtures/tc1/.yo-rc.json
@@ -1,5 +1,5 @@
 {
-  "*": {
+  "generator-spike": {
     "integrationTests": true
   }
 }

--- a/src/integrationTests/fixtures/tc1/Dockerfile
+++ b/src/integrationTests/fixtures/tc1/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:alpine
+
+# Install Yarn.
+RUN apk add --no-cache --virtual .build-deps \
+    ca-certificates \
+    wget \
+    tar && \
+    cd /usr/local/bin && \
+    wget https://yarnpkg.com/latest.tar.gz && \
+    tar zvxf latest.tar.gz && \
+    ln -s /usr/local/bin/dist/bin/yarn.js /usr/local/bin/yarn.js && \
+    apk del .build-deps
+
+EXPOSE 3000
+
+RUN mkdir -p /app
+WORKDIR /app
+
+COPY package.json ./
+RUN yarn
+
+COPY . .
+
+RUN npm run build
+CMD ["npm", "start"]

--- a/src/integrationTests/fixtures/tc1/docker-compose.integrationTests.yml
+++ b/src/integrationTests/fixtures/tc1/docker-compose.integrationTests.yml
@@ -1,0 +1,37 @@
+version: '3'
+
+services:
+  hub:
+    image: selenium/hub:latest
+    ports:
+    - 4444:4444
+  chrome:
+    image: selenium/node-chrome-debug:latest
+    depends_on:
+    - hub
+    ports:
+    - 5900:5900
+    environment:
+      HUB_PORT_4444_TCP_ADDR: hub
+      HUB_PORT_4444_TCP_PORT: 4444
+      no_proxy: localhost
+      HUB_ENV_no_proxy: localhost
+  firefox:
+    image: selenium/node-firefox-debug:latest
+    depends_on:
+    - hub
+    ports:
+    - 5901:5900
+    environment:
+      HUB_PORT_4444_TCP_ADDR: hub
+      HUB_PORT_4444_TCP_PORT: 4444
+      no_proxy: localhost
+      HUB_ENV_no_proxy: localhost
+  app:
+    image: "yada:${BUILD_NUMBER}"
+    command: npm run test:integration
+    depends_on:
+    - hub
+    environment:
+      BROWSER_ORIGIN: http://localhost:3000
+      SELENIUM_REMOTE_URL: http://hub:4444/wd/hub

--- a/src/integrationTests/fixtures/tc1/tests/integration/index.js
+++ b/src/integrationTests/fixtures/tc1/tests/integration/index.js
@@ -1,0 +1,63 @@
+import Mocha from 'mocha';
+import fs from 'fs';
+import path from 'path';
+import { argv, alias, help, options } from 'yargs';
+
+function addDirectory(mocha, testDir, regex = /\.test\.js$/) {
+  // Add each .js file to the mocha instance
+  fs.readdirSync(testDir)
+    .forEach((file) => {
+      const filePath = path.resolve(testDir, file);
+      if (fs.statSync(filePath).isDirectory()) {
+        return addDirectory(mocha, filePath, regex);
+      }
+
+      if (regex.test(file)) mocha.addFile(filePath);
+    });
+}
+
+function testRunner(opts) {
+  global.browser = opts.browser;
+
+  const setup = {
+    ui: 'bdd',
+    timeout: 100000,
+  };
+  if (opts.grep) setup.grep = opts.grep;
+  if (opts.invert) setup.invert = opts.invert;
+
+  // Instantiate a Mocha instance.
+  const mocha = new Mocha(setup);
+  // Include all tests in tests/integration.
+  addDirectory(mocha, __dirname);
+
+  // Run the tests.
+  mocha.run((failures) => {
+    process.exit(failures);  // exit with non-zero status if there were failures
+  });
+}
+
+// Config yargs
+help();
+alias('h', 'help');
+options({
+  browser: {
+    alias: 'b',
+    describe: 'Browser used by the automated test (chrome or firefox)',
+    default: 'chrome',
+  },
+  grep: {
+    alias: 'g',
+    type: 'string',
+    describe: 'Mocha grep option.',
+    default: '',
+  },
+  invert: {
+    alias: 'i',
+    type: 'boolean',
+    describe: 'Mocha invert option',
+    default: false,
+  },
+});
+
+testRunner(argv);

--- a/src/integrationTests/fixtures/tc1/tests/integration/openUrl.js
+++ b/src/integrationTests/fixtures/tc1/tests/integration/openUrl.js
@@ -1,0 +1,25 @@
+import config from 'config';
+import Url from 'url';
+import webdriver from 'selenium-webdriver';
+import until from 'selenium-webdriver/lib/until';
+
+function createSeleniumInstance(browser) {
+  return new webdriver.Builder()
+    .forBrowser(browser)
+    .build();
+}
+
+/**
+* This function opens a URL on browser and returns the driver.
+* @param {String} pathname Pathname of url
+* @param {Object} Query Query parameters to add to URL.
+* @returns {Promise} Promise resolving to Selenium driver instance.
+*/
+export default async function openUrl(pathname, query) {
+  const url = Url.parse(config.get('integrationTests.origin'));
+  url.pathname = pathname;
+  url.query = query;
+  const driver = await createSeleniumInstance();
+  await driver.get(Url.format(url));
+  return driver;
+}

--- a/src/integrationTests/fixtures/tc1/tests/integration/pages/Home/domActions.js
+++ b/src/integrationTests/fixtures/tc1/tests/integration/pages/Home/domActions.js
@@ -1,0 +1,9 @@
+import { By } from 'selenium-webdriver';
+import until from 'selenium-webdriver/lib/until';
+
+export async function jumps(){
+
+}
+export async function dances(){
+
+}

--- a/src/integrationTests/fixtures/tc1/tests/integration/pages/Home/domValidations.js
+++ b/src/integrationTests/fixtures/tc1/tests/integration/pages/Home/domValidations.js
@@ -1,0 +1,7 @@
+import { expect } from 'chai';
+import { By } from 'selenium-webdriver';
+import until from 'selenium-webdriver/lib/until';
+
+export const expectSpinner async function(){
+
+}

--- a/src/integrationTests/fixtures/tc1/tests/integration/pages/Home/index.js
+++ b/src/integrationTests/fixtures/tc1/tests/integration/pages/Home/index.js
@@ -1,0 +1,5 @@
+import Page from '../base';
+import * as actions from './domActions';
+import * as validations from './domValidations';
+
+export default new Page('/', actions, validations);

--- a/src/integrationTests/fixtures/tc1/tests/integration/pages/Login/domActions.js
+++ b/src/integrationTests/fixtures/tc1/tests/integration/pages/Login/domActions.js
@@ -1,0 +1,9 @@
+import { By } from 'selenium-webdriver';
+import until from 'selenium-webdriver/lib/until';
+
+export async function laughs(){
+
+}
+export async function cries(){
+
+}

--- a/src/integrationTests/fixtures/tc1/tests/integration/pages/Login/domValidations.js
+++ b/src/integrationTests/fixtures/tc1/tests/integration/pages/Login/domValidations.js
@@ -1,0 +1,7 @@
+import { expect } from 'chai';
+import { By } from 'selenium-webdriver';
+import until from 'selenium-webdriver/lib/until';
+
+export const expectSpinner async function(){
+
+}

--- a/src/integrationTests/fixtures/tc1/tests/integration/pages/Login/index.js
+++ b/src/integrationTests/fixtures/tc1/tests/integration/pages/Login/index.js
@@ -1,0 +1,5 @@
+import Page from '../base';
+import * as actions from './domActions';
+import * as validations from './domValidations';
+
+export default new Page('/login', actions, validations);

--- a/src/integrationTests/fixtures/tc1/tests/integration/pages/base.js
+++ b/src/integrationTests/fixtures/tc1/tests/integration/pages/base.js
@@ -1,0 +1,31 @@
+// Binding action and validation functions to the page will enable
+// actions and validations to access `page.driver`.
+function bindToPage(page, object){
+  return Object.keys(actions).reduce((bounded, key) => {
+    bounded[key] = object[key].bind(page);
+    return bounded;
+  }, {});
+}
+
+export default class Page {
+
+  constructor(pathname, actions, validations){
+    const boundActions =
+    Object.extend(this, {
+      pathname,
+      actions: bindToPage(this, actions),
+      validations: bindToPage(this, validations)
+    });
+  }
+
+  async open(query){
+    this.driver = await openUrl(this.pathname, this.query);
+  }
+
+  async close(){
+    const closed = await this.driver.close();
+    this.driver = undefined;
+    return closed;
+  }
+
+}

--- a/src/integrationTests/fixtures/tc1/tests/integration/pages/index.js
+++ b/src/integrationTests/fixtures/tc1/tests/integration/pages/index.js
@@ -1,0 +1,9 @@
+import * as Home from './Home';
+import * as Login from './Login';
+
+
+export default {
+  Home,
+  Login,
+  
+};

--- a/src/integrationTests/fixtures/tc1/tests/integration/testCases/HomeBaseCases.test.js
+++ b/src/integrationTests/fixtures/tc1/tests/integration/testCases/HomeBaseCases.test.js
@@ -1,0 +1,18 @@
+describe('Home base cases', () => {
+  let driver;
+  beforeEach(async () => {
+    driver = await pages.Home.open();
+  });
+
+  afterEach(async () => {
+    await driver.close();
+  });
+
+  it('jumps', async () => {
+    // TODO
+  });
+  it('dances', async () => {
+    // TODO
+  });
+  
+});

--- a/src/integrationTests/fixtures/tc1/tests/integration/testCases/LoginBaseCases.test.js
+++ b/src/integrationTests/fixtures/tc1/tests/integration/testCases/LoginBaseCases.test.js
@@ -1,0 +1,24 @@
+import config from 'config';
+import openUrl from 'tests/integration/openUrl';
+import { expect } from 'chai';
+import pages from 'tests/integration/pages';
+
+// use driver and page actions and validations: https://seleniumhq.github.io/selenium/docs/api/javascript/
+describe('Login base cases', () => {
+  let driver;
+  beforeEach(async () => {
+    driver = await pages.Login.open();
+  });
+
+  afterEach(async () => {
+    await driver.close();
+  });
+
+  it('laughs', async () => {
+    // TODO
+  });
+  it('cries', async () => {
+    // TODO
+  });
+  
+});

--- a/src/integrationTests/index.js
+++ b/src/integrationTests/index.js
@@ -3,6 +3,15 @@ import Base from '../base';
 
 module.exports = class IntegrationTests extends Base {
 
+  /**
+   * Initializing
+   */
+
+  intializing() {
+    // FIXME: For some reason, unit tests config namespace is "*".
+    this.config.name = 'generator-spike';
+  }
+
   /*
    * Prompting
    */

--- a/src/integrationTests/index.js
+++ b/src/integrationTests/index.js
@@ -1,0 +1,253 @@
+import path from 'path';
+import Base from '../base';
+
+module.exports = class IntegrationTests extends Base {
+
+  /*
+   * Prompting
+   */
+
+  async prompting() {
+    if (!this.config.get('integrationTests')) {
+      await this._promptConfig();
+    } else {
+      this.log.info('You integration test scaffolding has already been created.');
+    }
+    this.answers = {
+      pages: [],
+      actions: []
+    };
+    return this._promptPagesAndTests();
+  }
+
+  async _promptConfig() {
+    this.answers.config = await this.prompt([
+      {
+        type: 'input',
+        name: 'frontendPort',
+        message: 'When running tests locally, what port will serve your app on?'
+      }, {
+        type: 'input',
+        name: 'dockerImageName',
+        message: 'Docker image name for CI builds.'
+      }, {
+        type: 'input',
+        name: 'dockerImageTag',
+        message: 'Docker image tags for CI builds.',
+        // eslint-disable-next-line no-template-curly-in-string
+        default: '${BRANCH_NAME}_${BUILD_NUMBER}'
+      }
+    ]);
+    return undefined;
+  }
+
+  async _promptPagesAndTests() {
+    const { generatePages } = await this.prompt([
+      {
+        type: 'list',
+        name: 'generatePages',
+        message: 'Do you want to generate page configuration, actions, and validations?',
+        choices: [
+          { name: 'Yes', value: true },
+          { name: 'No', value: false }
+        ]
+      }
+    ]);
+    if (generatePages) {
+      await this._promptPages();
+    }
+
+    const { generateTests } = await this.prompt([
+      {
+        type: 'list',
+        name: 'generateTests',
+        message: 'Do you want to generate some test cases?',
+        choices: [
+          { name: 'Yes', value: true },
+          { name: 'No', value: false }
+        ]
+      }
+    ]);
+    if (generateTests) {
+      await this._promptTests();
+    }
+
+    return undefined;
+  }
+
+  async _promptPages() {
+    const page = await this.prompt([
+      {
+        type: 'input',
+        name: 'name',
+        message: 'Name of page (used as filename and accessor from \'pages\' object within tests). We suggest using CapitalCamelCase.'
+      }, {
+        type: 'input',
+        name: 'pathname',
+        message: 'What URL path can access this page?'
+      }]);
+
+      // TODO
+    page.actions = await this._promptActions(page, []);
+    page.validations = await this._promptValidations(page, []);
+
+    this.answers.pages.push(page);
+
+    const { more } = await this.prompt([
+      {
+        type: 'list',
+        message: 'Add more pages?',
+        name: 'more',
+        choices: [
+          { name: 'Yes', value: true },
+          { name: 'No', value: false }
+        ]
+      }
+    ]);
+
+    if (more) {
+      return this._promptPages();
+    }
+    return undefined;
+  }
+
+  async _promptTests() {
+    const test = await this.prompt([
+      {
+        type: 'input',
+        name: 'filename',
+        message: 'Filename of test.'
+      }, {
+        type: 'input',
+        name: 'pageName',
+        message: 'Accessor from \'pages\' accessor'
+      }, {
+        type: 'input',
+        name: 'description',
+        message: 'Description for top line Mocha \'describe\' statement.'
+      }
+    ]);
+
+    test.assertions = await this._promptAssertions(test, []);
+
+    this.answers.tests.push(test);
+
+    const { more } = await this.prompt([
+      {
+        type: 'list',
+        message: 'Add more tests?',
+        name: 'more',
+        choices: [
+          { name: 'Yes', value: true },
+          { name: 'No', value: false }
+        ]
+      }]);
+
+    if (more) {
+      return this._promptTests();
+    }
+    return undefined;
+  }
+
+  async _promptAssertions(test, assertions) {
+    const { assertion, more } = await this.prompt([
+      {
+        type: 'input',
+        name: 'assertion',
+        message: 'Assertion for Mocha \'it\' statement.'
+      }, {
+        type: 'list',
+        message: 'More assertions?',
+        name: 'more',
+        choices: [
+          { name: 'Yes', value: true },
+          { name: 'No', value: false }
+        ]
+      }
+    ]);
+
+    assertions.push(assertion);
+
+    if (more) {
+      return this._promptAssertions(test, assertions);
+    }
+    return assertions;
+  }
+
+  /**
+   * Writing
+   */
+
+  async writing() {
+    this.sourceRoot(path.join(__dirname, 'templates'));
+    if (!this.config.get('integrationTests')) {
+      await this._writeScaffolding();
+    }
+    await this._writePages();
+    await this._writeTests();
+    this.config.set('integrationTests', true);
+  }
+
+  async _writeScaffolding() {
+    [
+      '.dockerignore',
+      'docker-compose.integrationTests.yml.ejs',
+      'Dockerfile.ejs',
+      'tests/integration/index.js',
+      'tests/integration/openUrl.js',
+      'tests/integration/pages/base.js',
+      'tests/integration/pages/index.js.ejs'
+    ].forEach((templateName) => {
+      const filePath = templateName.replace(/\.ejs$/, '');
+      this.fs.copyTpl(
+        this.templatePath(templateName),
+        this.destinationPath(filePath),
+        {
+          ...this.answers.config,
+          pages: this.answers.pages
+        }
+      );
+    });
+    this.log.info('docker-compose.integrationTests.yml use Selenium docker images with \'-debug\' suffix.');
+    this.log.info('For more information see https://github.com/SeleniumHQ/docker-selenium.');
+    this.log.invoke('Make sure to add "integrationTests.origin" to your config/test.js file:');
+  }
+
+  async _writePages() {
+    this.answers.pages.forEach((page) => {
+      [
+        'tests/integration/pages/page/domActions.js.ejs',
+        'tests/integration/pages/page/domValidations.js.ejs',
+        'tests/integration/pages/page/index.js.ejs'
+      ].forEach((templateName) => {
+        const filePath = templateName
+          .replace(/\.ejs$/, '')
+          .replace(/\/page\//, `/${page.name}/`);
+        this.fs.copyTpl(
+          this.templatePath(templateName),
+          this.destinationPath(filePath),
+          { page }
+        );
+      });
+    });
+  }
+
+  async _writeTests() {
+    this.answers.tests.forEach((test) => {
+      this.fs.copyTpl(
+        this.templatePath('tests/integration/testCases/test.js.ejs'),
+        this.destinationPath(`tests/integration/testCases/${test.filename}.test.js`),
+        { test }
+      );
+    });
+  }
+
+  /**
+   * Installing
+   */
+
+  async installing() {
+    this.yarnInstall(['selenium-webdriver']);
+  }
+
+};

--- a/src/integrationTests/integrationTests.test.js
+++ b/src/integrationTests/integrationTests.test.js
@@ -1,0 +1,78 @@
+import fs from 'fs-extra';
+import path from 'path';
+import helpers from 'yeoman-test';
+import assert from 'yeoman-assert';
+import { assertFixtureMatch } from 'testUtils';
+import IntegrationTests from './index';
+
+describe('spike:integrationTests', () => {
+  const { prompting } = IntegrationTests.prototype;
+  after(() => {
+    IntegrationTests.prototype.prompting = prompting;
+  });
+
+  context('when integration tests are not yet scaffolded.', () => {
+    before(() => {
+      IntegrationTests.prototype.prompting = async function promptingStub() {
+        // eslint-disable-next-line no-template-curly-in-string
+        const config = { frontendPort: 3000, dockerImageName: 'yada', dockerImageTag: '${BUILD_NUMBER}' };
+        const pages = [
+          { name: 'Home', pathname: '/', actions: ['jumps', 'dances'], validations: ['expectSpinner'] },
+          { name: 'Login', pathname: '/login', actions: ['laughs', 'cries'], validations: ['expectSpinner'] }
+        ];
+        const tests = [
+          { pageName: 'Home', description: 'base cases', filename: 'HomeBaseCases', assertions: ['jumps', 'dances'] },
+          { pageName: 'Login', description: 'base cases', filename: 'LoginBaseCases', assertions: ['laughs', 'cries'] }
+        ];
+        this.answers = { pages, tests, config };
+      };
+    });
+    it('can create scaffolding, new pages, and new actions.', async () => {
+      await helpers.run(IntegrationTests);
+      await Promise.all([
+        '.yo-rc.json',
+        '.dockerignore',
+        'Dockerfile',
+        'docker-compose.integrationTests.yml',
+        'tests/integration/index.js',
+        'tests/integration/openUrl.js',
+        'tests/integration/pages/base.js',
+        'tests/integration/pages/index.js',
+        'tests/integration/pages/Home/index.js',
+        'tests/integration/pages/Home/domValidations.js',
+        'tests/integration/pages/Home/domActions.js',
+        'tests/integration/pages/Login/index.js',
+        'tests/integration/pages/Login/domValidations.js',
+        'tests/integration/pages/Login/domActions.js',
+        'tests/integration/testCases/HomeBaseCases.test.js',
+        'tests/integration/testCases/LoginBaseCases.test.js'
+      ].map(filepath => assertFixtureMatch(filepath, path.resolve(__dirname, 'fixtures/tc1', filepath))));
+    });
+  });
+
+  context('when integration tests already scaffolded.', () => {
+    before(() => {
+      IntegrationTests.prototype.prompting = async function promptingStub() {
+        const pages = [
+          { name: 'Dog', pathname: '/dog', actions: ['growls', 'barks'], validations: ['expectToBeTrained'] }
+        ];
+        const tests = [
+          { pageName: 'Dog', description: 'walking in the park', filename: 'DogInPark', assertions: ['barks', 'growls'] }
+        ];
+        this.answers = { pages, tests };
+      };
+    });
+    it('skips scaffolding and just adds new files', async () => {
+      await helpers.run(IntegrationTests)
+        .inTmpDir((dir) => {
+          fs.copySync(path.join(__dirname, 'fixtures/tc1'), dir);
+        });
+      assert.file([
+        'tests/integration/testCases/DogInPark.test.js',
+        'tests/integration/pages/Dog/index.js',
+        'tests/integration/pages/Dog/domValidations.js',
+        'tests/integration/pages/Dog/domActions.js'
+      ]);
+    });
+  });
+});

--- a/src/integrationTests/templates/.dockerignore
+++ b/src/integrationTests/templates/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/integrationTests/templates/Dockerfile.ejs
+++ b/src/integrationTests/templates/Dockerfile.ejs
@@ -1,0 +1,25 @@
+FROM node:alpine
+
+# Install Yarn.
+RUN apk add --no-cache --virtual .build-deps \
+    ca-certificates \
+    wget \
+    tar && \
+    cd /usr/local/bin && \
+    wget https://yarnpkg.com/latest.tar.gz && \
+    tar zvxf latest.tar.gz && \
+    ln -s /usr/local/bin/dist/bin/yarn.js /usr/local/bin/yarn.js && \
+    apk del .build-deps
+
+EXPOSE <%= frontendPort %>
+
+RUN mkdir -p /app
+WORKDIR /app
+
+COPY package.json ./
+RUN yarn
+
+COPY . .
+
+RUN npm run build
+CMD ["npm", "start"]

--- a/src/integrationTests/templates/docker-compose.integrationTests.yml.ejs
+++ b/src/integrationTests/templates/docker-compose.integrationTests.yml.ejs
@@ -1,0 +1,37 @@
+version: '3'
+
+services:
+  hub:
+    image: selenium/hub:latest
+    ports:
+    - 4444:4444
+  chrome:
+    image: selenium/node-chrome-debug:latest
+    depends_on:
+    - hub
+    ports:
+    - 5900:5900
+    environment:
+      HUB_PORT_4444_TCP_ADDR: hub
+      HUB_PORT_4444_TCP_PORT: 4444
+      no_proxy: localhost
+      HUB_ENV_no_proxy: localhost
+  firefox:
+    image: selenium/node-firefox-debug:latest
+    depends_on:
+    - hub
+    ports:
+    - 5901:5900
+    environment:
+      HUB_PORT_4444_TCP_ADDR: hub
+      HUB_PORT_4444_TCP_PORT: 4444
+      no_proxy: localhost
+      HUB_ENV_no_proxy: localhost
+  app:
+    image: "<%= dockerImageName %>:<%= dockerImageTag %>"
+    command: npm run test:integration
+    depends_on:
+    - hub
+    environment:
+      BROWSER_ORIGIN: http://localhost:<%= frontendPort %>
+      SELENIUM_REMOTE_URL: http://hub:4444/wd/hub

--- a/src/integrationTests/templates/tests/integration/index.js
+++ b/src/integrationTests/templates/tests/integration/index.js
@@ -1,0 +1,63 @@
+import Mocha from 'mocha';
+import fs from 'fs';
+import path from 'path';
+import { argv, alias, help, options } from 'yargs';
+
+function addDirectory(mocha, testDir, regex = /\.test\.js$/) {
+  // Add each .js file to the mocha instance
+  fs.readdirSync(testDir)
+    .forEach((file) => {
+      const filePath = path.resolve(testDir, file);
+      if (fs.statSync(filePath).isDirectory()) {
+        return addDirectory(mocha, filePath, regex);
+      }
+
+      if (regex.test(file)) mocha.addFile(filePath);
+    });
+}
+
+function testRunner(opts) {
+  global.browser = opts.browser;
+
+  const setup = {
+    ui: 'bdd',
+    timeout: 100000,
+  };
+  if (opts.grep) setup.grep = opts.grep;
+  if (opts.invert) setup.invert = opts.invert;
+
+  // Instantiate a Mocha instance.
+  const mocha = new Mocha(setup);
+  // Include all tests in tests/integration.
+  addDirectory(mocha, __dirname);
+
+  // Run the tests.
+  mocha.run((failures) => {
+    process.exit(failures);  // exit with non-zero status if there were failures
+  });
+}
+
+// Config yargs
+help();
+alias('h', 'help');
+options({
+  browser: {
+    alias: 'b',
+    describe: 'Browser used by the automated test (chrome or firefox)',
+    default: 'chrome',
+  },
+  grep: {
+    alias: 'g',
+    type: 'string',
+    describe: 'Mocha grep option.',
+    default: '',
+  },
+  invert: {
+    alias: 'i',
+    type: 'boolean',
+    describe: 'Mocha invert option',
+    default: false,
+  },
+});
+
+testRunner(argv);

--- a/src/integrationTests/templates/tests/integration/openUrl.js
+++ b/src/integrationTests/templates/tests/integration/openUrl.js
@@ -1,0 +1,25 @@
+import config from 'config';
+import Url from 'url';
+import webdriver from 'selenium-webdriver';
+import until from 'selenium-webdriver/lib/until';
+
+function createSeleniumInstance(browser) {
+  return new webdriver.Builder()
+    .forBrowser(browser)
+    .build();
+}
+
+/**
+* This function opens a URL on browser and returns the driver.
+* @param {String} pathname Pathname of url
+* @param {Object} Query Query parameters to add to URL.
+* @returns {Promise} Promise resolving to Selenium driver instance.
+*/
+export default async function openUrl(pathname, query) {
+  const url = Url.parse(config.get('integrationTests.origin'));
+  url.pathname = pathname;
+  url.query = query;
+  const driver = await createSeleniumInstance();
+  await driver.get(Url.format(url));
+  return driver;
+}

--- a/src/integrationTests/templates/tests/integration/pages/base.js
+++ b/src/integrationTests/templates/tests/integration/pages/base.js
@@ -1,0 +1,31 @@
+// Binding action and validation functions to the page will enable
+// actions and validations to access `page.driver`.
+function bindToPage(page, object){
+  return Object.keys(actions).reduce((bounded, key) => {
+    bounded[key] = object[key].bind(page);
+    return bounded;
+  }, {});
+}
+
+export default class Page {
+
+  constructor(pathname, actions, validations){
+    const boundActions =
+    Object.extend(this, {
+      pathname,
+      actions: bindToPage(this, actions),
+      validations: bindToPage(this, validations)
+    });
+  }
+
+  async open(query){
+    this.driver = await openUrl(this.pathname, this.query);
+  }
+
+  async close(){
+    const closed = await this.driver.close();
+    this.driver = undefined;
+    return closed;
+  }
+
+}

--- a/src/integrationTests/templates/tests/integration/pages/index.js.ejs
+++ b/src/integrationTests/templates/tests/integration/pages/index.js.ejs
@@ -1,0 +1,7 @@
+<% pages.forEach(page => { %>import * as <%= page.name %> from './<%= page.name %>';
+<% }); %>
+
+export default {
+  <% pages.forEach(page => { %><%= page.name %>,
+  <% }); %>
+};

--- a/src/integrationTests/templates/tests/integration/pages/page/domActions.js.ejs
+++ b/src/integrationTests/templates/tests/integration/pages/page/domActions.js.ejs
@@ -1,0 +1,7 @@
+import { By } from 'selenium-webdriver';
+import until from 'selenium-webdriver/lib/until';
+
+<% page.actions.forEach(action => { %>export async function <%= action %>(){
+
+}
+<% }); %>

--- a/src/integrationTests/templates/tests/integration/pages/page/domValidations.js.ejs
+++ b/src/integrationTests/templates/tests/integration/pages/page/domValidations.js.ejs
@@ -1,0 +1,8 @@
+import { expect } from 'chai';
+import { By } from 'selenium-webdriver';
+import until from 'selenium-webdriver/lib/until';
+
+export const <% page.validations.forEach(validation => { %><%= validation %> async function(){
+
+}
+<% }); %>

--- a/src/integrationTests/templates/tests/integration/pages/page/index.js.ejs
+++ b/src/integrationTests/templates/tests/integration/pages/page/index.js.ejs
@@ -1,0 +1,5 @@
+import Page from '../base';
+import * as actions from './domActions';
+import * as validations from './domValidations';
+
+export default new Page('<%= page.pathname %>', actions, validations);

--- a/src/integrationTests/templates/tests/integration/testCases/test.js.ejs
+++ b/src/integrationTests/templates/tests/integration/testCases/test.js.ejs
@@ -1,0 +1,21 @@
+import config from 'config';
+import openUrl from 'tests/integration/openUrl';
+import { expect } from 'chai';
+import pages from 'tests/integration/pages';
+
+// use driver and page actions and validations: https://seleniumhq.github.io/selenium/docs/api/javascript/
+describe('<%= test.pageName %> <%= test.description %>', () => {
+  let driver;
+  beforeEach(async () => {
+    driver = await pages.<%= test.pageName %>.open();
+  });
+
+  afterEach(async () => {
+    await driver.close();
+  });
+
+  <% test.assertions.forEach(assertion => { %>it('<%= assertion %>', async () => {
+    // TODO
+  });
+  <% }); %>
+});

--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -1,0 +1,14 @@
+import fs from 'fs';
+// eslint-disable-next-line
+import assert from 'yeoman-assert';
+
+// eslint-disable-next-line import/prefer-default-export
+export async function assertFixtureMatch(path, fixturePath) {
+  const content = await new Promise((fnResolve, fnReject) => {
+    fs.readFile(fixturePath, 'utf8', (err, data) => {
+      if (err) return fnReject(err);
+      return fnResolve(data);
+    });
+  });
+  assert.fileContent(path, content.trim());
+}

--- a/test.js
+++ b/test.js
@@ -24,7 +24,7 @@ function addDirectory(testDir, exclude, regex = /\.test\.jsx?$/) {
     });
 }
 
-addDirectory(path.resolve(__dirname, 'src'), /templates/);
+addDirectory(path.resolve(__dirname, 'src'), /(templates|fixtures)/);
 
 // Run the tests.
 mocha.run((failures) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -795,7 +795,7 @@ caseless@~0.12.0:
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
 
-"chalk@>= 1.1.3", chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -1589,6 +1589,14 @@ formatio@1.1.1:
   dependencies:
     samsam "~1.1"
 
+"fs-extra@>= 3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^3.0.0"
+    universalify "^0.1.0"
+
 fs-readdir-recursive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz#8cd1745c8b4f8a29c8caec392476921ba195f560"
@@ -1796,7 +1804,7 @@ got@^6.2.0:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.4:
+graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -2216,6 +2224,12 @@ json3@3.3.2:
 json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+
+jsonfile@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.0.tgz#92e7c7444e5ffd5fa32e6a9ae8b85034df8347d0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsonify@~0.0.0:
   version "0.0.0"
@@ -3385,6 +3399,10 @@ underscore.string@^3.0.3:
   dependencies:
     sprintf-js "^1.0.3"
     util-deprecate "^1.0.2"
+
+universalify@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.0.tgz#9eb1c4651debcc670cc94f1a75762332bb967778"
 
 untildify@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
**What**
- Create generators for integration tests - scaffolding, test cases, and page actions/validations.

**Why**
- facilitating E2E testing will be a big differentiator for Spike.

**How**
- The generator will first check to see if integration test scaffolding has been generated yet. If not, it will be generated.
- Client then asks if the user wants to generate a new page including dom actions and validations.
- Last, client asks if the user wants to generate test cases.